### PR TITLE
Statically link VC runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 cmake-build*/
 .gradle/
+*.log

--- a/opus-jni-native/CMakeLists.txt
+++ b/opus-jni-native/CMakeLists.txt
@@ -1,3 +1,9 @@
+###################
+# Policy settings #
+###################
+cmake_policy(SET CMP0091 NEW)
+cmake_policy(SET CMP0048 NEW)
+
 #################
 # Project setup #
 #################
@@ -42,3 +48,15 @@ set(OPUS_JNI_NATIVE_SOURCES
 add_library(opus-jni-native SHARED ${OPUS_JNI_NATIVE_SOURCES})
 target_link_libraries(opus-jni-native PUBLIC opus ${JNI_LIBRARIES})
 target_include_directories(opus-jni-native PUBLIC ${JNI_INCLUDE_DIRS} ${GENERATED_JNI_HEADERS_DIR})
+
+if(MSVC)
+    set_property(
+            TARGET opus
+            PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDebug":wq
+    )
+
+    set_property(
+            TARGET opus-jni-native
+            PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDebug"
+    )
+endif()

--- a/opus-jni-native/CMakeLists.txt
+++ b/opus-jni-native/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(opus-jni-native PUBLIC ${JNI_INCLUDE_DIRS} ${GENERATE
 if(MSVC)
     set_property(
             TARGET opus
-            PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDebug":wq
+            PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDebug"
     )
 
     set_property(


### PR DESCRIPTION
The Microsoft compiler usually links the runtime library dynamically which can cause issues in case the user has not installed the VCRuntime packages. To get around this, we simply link the runtime into the resulting DLL.